### PR TITLE
Feature/frontend validation

### DIFF
--- a/client/src/components/Modals/EmailModal.tsx
+++ b/client/src/components/Modals/EmailModal.tsx
@@ -1,39 +1,103 @@
+import React, { useEffect, useState } from "react";
+
 type Props = {
     open: boolean;
     loading?: boolean;
     onClose: () => void;
     onSubmit: (oldMail: string, newMail: string) => void;
+    externalErrors?: { old?: string; new?: string };
 };
 
-const EmailModal: React.FC<Props> = ({open, loading, onClose, onSubmit}) => {
+const EmailModal: React.FC<Props> = ({ open, loading, onClose, onSubmit, externalErrors }) => {
+    const [errors, setErrors] = useState<{ old?: string; new?: string }>({});
+    const [oldEmail, setOldEmail] = useState("");
+    const [newEmail, setNewEmail] = useState("");
+
+    useEffect(() => {
+        if (open) {
+            setErrors(externalErrors || {});
+        }
+    }, [externalErrors, open]);
+
+    useEffect(() => {
+        if (!open) {
+            setOldEmail("");
+            setNewEmail("");
+            setErrors({});
+        }
+    }, [open]);
+
+    const requiredHint = (msg?: string) => (
+        <p
+            className={`text-red-500 text-xs text-left transition-opacity duration-200 h-[0.3rem] ${
+                msg ? "opacity-100" : "opacity-0"
+            }`}
+        >
+            {msg || " "}
+        </p>
+    );
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        const newErrors: { old?: string; new?: string } = {};
+
+        if (!oldEmail) newErrors.old = "Current email is required";
+        if (!newEmail) {
+            newErrors.new = "New email is required";
+        } else if (!/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/.test(newEmail)) {
+            newErrors.new = "Enter a valid email address";
+        } else if (oldEmail.trim() === newEmail.trim()) {
+            newErrors.new = "New email must be different from the current email";
+        }
+
+        setErrors(newErrors);
+
+        if (Object.keys(newErrors).length === 0) {
+            onSubmit(oldEmail.trim(), newEmail.trim());
+        }
+    };
+
+
     if (!open) return null;
 
     return (
         <dialog open className="modal modal-middle">
             <form
-                onSubmit={e => {
-                    e.preventDefault();
-                    const fd = new FormData(e.currentTarget);
-                    onSubmit(fd.get("old") as string, fd.get("new") as string);
-                }}
+                onSubmit={handleSubmit}
                 method="dialog"
                 className="modal-box max-w-md space-y-5"
+                noValidate
             >
-                <h3 className="text-center text-xl font-semibold">Changing e-mailaddress</h3>
+                <h3 className="text-center text-xl font-semibold">Changing e-mail address</h3>
                 <p className="text-center text-gray-500 text-sm -mt-3">
                     When you change to a new e-mail address, you need to confirm the address before the change is made.
                 </p>
 
-                <label className="block">
-                    <span className="label-text mb-1">Current e-mailaddress</span>
-                    <input name="old" type="email" className="input input-bordered w-full" placeholder="Email"
-                           required/>
+                <label className="block space-y-1">
+                    <span className="label-text mb-1">Current e-mail address</span>
+                    <input
+                        name="old"
+                        type="email"
+                        value={oldEmail}
+                        onChange={(e) => setOldEmail(e.target.value)}
+                        className={`input input-bordered input-sm w-full bg-white text-black pr-10 ${errors.old ? "border-red-500" : ""}`}
+                        placeholder="Current e-mail"
+                    />
+                    {requiredHint(errors.old)}
                 </label>
 
-                <label className="block">
-                    <span className="label-text mb-1">New e-mailaddress</span>
-                    <input name="new" type="email" className="input input-bordered w-full" placeholder="Email"
-                           required/>
+                <label className="block space-y-1">
+                    <span className="label-text mb-1">New e-mail address</span>
+                    <input
+                        name="new"
+                        type="email"
+                        value={newEmail}
+                        onChange={(e) => setNewEmail(e.target.value)}
+                        className={`input input-bordered input-sm w-full bg-white text-black pr-10 ${errors.old ? "border-red-500" : ""}`}
+                        placeholder="New e-mail"
+                    />
+                    {requiredHint(errors.new)}
                 </label>
 
                 <div className="modal-action mt-6">

--- a/client/src/components/Modals/PasswordModal.tsx
+++ b/client/src/components/Modals/PasswordModal.tsx
@@ -43,16 +43,22 @@ const PasswordModal: React.FC<Props> = ({open, loading, onClose, onSubmit, exter
         const newPassword = fd.get("new") as string;
         const confirm = fd.get("confirm") as string;
 
+        const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$/;
         const newErrors: Partial<PasswordDto> = {};
 
-        if (!oldPassword) newErrors.oldPassword = "Current password is required";
-        const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$/;
+        if (!oldPassword) {
+            newErrors.oldPassword = "Current password is required";
+        } else if (!passwordRegex.test(oldPassword)) {
+            newErrors.oldPassword =
+                "Current password must be ≥6 chars, include uppercase, lowercase, number & special character";
+        }
+
 
         if (!newPassword) {
             newErrors.newPassword = "New password is required";
         } else if (!passwordRegex.test(newPassword)) {
             newErrors.newPassword =
-                "At least 6 chars, including uppercase, lowercase, and special character.";
+                "At least 6 chars, including uppercase, lowercase, number & special character";
         }
 
         if (confirm !== newPassword) {

--- a/client/src/pages/Auth/AuthScreen.tsx
+++ b/client/src/pages/Auth/AuthScreen.tsx
@@ -134,7 +134,7 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
             onLogin?.();
         } catch (err) {
             console.error("Login error", err);
-            toast.error("Login failed");
+            toast.error("Incorrect email or password.", { id: "login-failed" });
         }
     };
 
@@ -214,7 +214,7 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
                 password,
             } as AuthRegisterDto);
             reset();
-            toast.success("Registered successfully! You can now log in.");
+            toast.success("Registered successfully! You can now log in.", { id: "register-success" });
         } catch (error: any) {
             console.error("Registration failed:", error);
 
@@ -230,7 +230,7 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
             if (title.includes("Email: User with that email already exists")) {
                 setRegisterErrors({email: "User with that email already exists"});
             } else {
-                toast.error("Registration failed. Try again.");
+                toast.error("Registration failed. Try again.", { id: "register-failed" });
             }
         }
     };

--- a/client/src/pages/Auth/AuthScreen.tsx
+++ b/client/src/pages/Auth/AuthScreen.tsx
@@ -42,6 +42,9 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
     const loginFormRef = useRef<HTMLFormElement>(null);
     const [loginErrors, setLoginErrors] = useState<{ email?: string; password?: string }>({});
     const { subscribe } = useTopicManager();
+    const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$/;
+    const passwordErrorMsg =
+        "At least 6 chars, including uppercase, lowercase, and special character.";
 
     // ANIMATION ---
     useLayoutEffect(() => {
@@ -57,7 +60,18 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
         } else {
             wrapper.style.height = "5rem";
         }
-    }, [mode, registerErrors]);
+
+        // Only clear errors if there are errors currently set
+        setRegisterErrors((prev) => {
+            if (Object.keys(prev).length === 0) return prev;
+            return {};
+        });
+
+        setLoginErrors((prev) => {
+            if (Object.keys(prev).length === 0) return prev;
+            return {};
+        });
+    }, [mode]);
 
     useEffect(() => {
         if (mode !== "login") {
@@ -101,8 +115,8 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
 
         if (!password) {
             errors.password = "Password is required";
-        } else if (password.length < 4) {
-            errors.password = "Password must be at least 4 characters.";
+        } else if (!passwordRegex.test(password)) {
+            errors.password = passwordErrorMsg;
         }
 
         return errors;

--- a/client/src/pages/Auth/AuthScreen.tsx
+++ b/client/src/pages/Auth/AuthScreen.tsx
@@ -44,7 +44,7 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
     const { subscribe } = useTopicManager();
     const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$/;
     const passwordErrorMsg =
-        "At least 6 chars, including uppercase, lowercase, and special character.";
+        "≥6 chars, incl. min. 1 uppercase, lowercase, digit & special.";
 
     // ANIMATION ---
     useLayoutEffect(() => {
@@ -146,9 +146,12 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
             setUserId(Id);
 
             onLogin?.();
-        } catch (err) {
+        } catch (err: any) {
             console.error("Login error", err);
-            toast.error("Incorrect email or password.", { id: "login-failed" });
+            setLoginErrors({
+                email: " ",
+                password: "Incorrect email or password.",
+            });
         }
     };
 
@@ -332,12 +335,10 @@ const AuthScreen: React.FC<AuthScreenProps> = ({onLogin}) => {
                         {requiredHint(loginErrors.email)}
 
                         <label className="label -mt-8 py-0 text-white">Password</label>
-                        <input
+                        <PasswordField
                             name="password"
                             placeholder="Password"
-                            type="password"
-                            className={`bg-white input input-bordered input-sm w-full text-black ${loginErrors.password ? errorClass : ""}`}
-                            required
+                            className={`bg-white ${loginErrors.password && errorClass}`}
                         />
                         {requiredHint(loginErrors.password)}
 

--- a/client/src/pages/UserSettings/UserSettings.tsx
+++ b/client/src/pages/UserSettings/UserSettings.tsx
@@ -41,7 +41,7 @@ const UserSettings: React.FC<Props> = () => {
                 setUser(u);
             } catch (error) {
                 console.error(error);
-                toast.error("Couldn't load user info");
+                toast.error("Couldn't load user info", { id: "loadUserInfo-failed" });
             }
         })();
     }, [jwt]);
@@ -60,12 +60,12 @@ const UserSettings: React.FC<Props> = () => {
             setSaving(true);
             if (!jwt) return;
             await userClient.deleteUser(jwt);
-            toast.success("Account deleted – goodbye!");
+            toast.success("Account deleted – goodbye!", { id: "accountDeleted-succes" });
             localStorage.removeItem("jwt");
             setJwt("");
             logout();
         } catch (e: any) {
-            toast.error(e.message ?? "Failed");
+            toast.error(e.message ?? "Failed", { id: "accountDeleted-failed" });
         } finally {
             setSaving(false);
         }
@@ -83,7 +83,7 @@ const UserSettings: React.FC<Props> = () => {
                 oldPassword: dto.oldPassword,
                 newPassword: dto.newPassword,
             });
-            toast.success("Password updated");
+            toast.success("Password updated", { id: "passwordChange-succes" });
             setOpenPassword(false);
             setPasswordErrors({});
         } catch (e: any) {
@@ -94,7 +94,7 @@ const UserSettings: React.FC<Props> = () => {
             if (status === 401 || /invalid/i.test(errorMessage)) {
                 setPasswordErrors({ oldPassword: "Old password is incorrect" });
             } else {
-                toast.error(errorMessage || "Failed to change password");
+                toast.error(errorMessage || "Failed to change password", { id: "passwordChange-failed" });
             }
         } finally {
             setSaving(false);
@@ -103,7 +103,7 @@ const UserSettings: React.FC<Props> = () => {
 
     async function handleEmail(oldMail: string, newMail: string) {
         if (oldMail !== user?.email) {
-            setEmailErrors({ old: "This is not your current mail" });
+            setEmailErrors({ old: "This is not your current email" });
             return;
         }
 
@@ -114,14 +114,25 @@ const UserSettings: React.FC<Props> = () => {
                 oldEmail: oldMail,
                 newEmail: newMail,
             });
-            toast.success("E-mail updated – please log in with the new address.");
+            toast.success("E-mail updated – please log in with the new address.", { id: "emailChange-succes" });
             setOpenEmail(false);
         } catch (e: any) {
-            toast.error(e.message ?? "Failed");
-        } finally {
+            const resp = typeof e.response === "string"
+                ? JSON.parse(e.response) || {}
+                : e.response || {};
+
+            const status = resp.status ?? e.status;
+            const title  = (resp.title ?? "").replace(/[\r\n]+/g, " ");
+
+            if (status === 400 && /email already used/i.test(title)) {
+                setEmailErrors({ new: "This email is already in use by another user" });
+            } else {
+                toast.error(title || e.message || "Failed to update email");
+            }
+
+    } finally {
             setSaving(false);
         }
-        //setEmailErrors({ new: "Another user already use this mail"});
     }
 
     if (!settings) {
@@ -224,8 +235,8 @@ const UserSettings: React.FC<Props> = () => {
                     {!user ? (
                         <p className="italic text-fluid">Loading profile…</p>
                     ) : (
-                        <div className="space-y-2 text-fluid">
-                            <h3 className="text-lg font-semibold">Account details</h3>
+                        <div className="space-y-2 ">
+                            <h3 className="text-lg md:text-xl lg:text-2xl font-semibold">Account details</h3>
 
                             <p>
                                 <span className="font-medium">Name:</span>{" "}

--- a/server/Application/Validation/Auth/AuthLoginDtoValidator.cs
+++ b/server/Application/Validation/Auth/AuthLoginDtoValidator.cs
@@ -14,6 +14,7 @@ public sealed class AuthLoginDtoValidator : AbstractValidator<AuthLoginDto>
         
         RuleFor(x => x.Password)
             .NotEmpty().WithMessage("Password cannot be empty")
-            .MinimumLength(4).WithMessage("Password cannot be shorter than 4 characters");
+            .Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$")
+            .WithMessage("Password must be at least 6 characters and include uppercase, lowercase, number, and special character.");
     }
 }

--- a/server/Application/Validation/Auth/AuthRegisterDtoValidator.cs
+++ b/server/Application/Validation/Auth/AuthRegisterDtoValidator.cs
@@ -32,7 +32,8 @@ public sealed class AuthRegisterDtoValidator : AbstractValidator<AuthRegisterDto
 
         RuleFor(x => x.Password)
             .NotEmpty().WithMessage("Password cannot be empty")
-            .MinimumLength(4).WithMessage("Password cannot be shorter than 4 characters");
+            .Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$")
+            .WithMessage("Password must be at least 6 characters and include uppercase, lowercase, number, and special character.");
         
         RuleFor(x => x.Country)
             .NotEmpty().WithMessage("Country cannot be empty")

--- a/server/Application/Validation/GlobalValidator.cs
+++ b/server/Application/Validation/GlobalValidator.cs
@@ -46,39 +46,39 @@ namespace Application.Validation
         {
             if (!IsConditionFormatValid(condition, sensorType)) return false;
 
-            if (sensorType == "Temperature")
+            if (sensorType != "Temperature") return IsOtherSensorConditionValueInRange(condition, sensorType);
+            var singleMatch = SingleConditionTempRegex().Match(condition);
+            if (singleMatch.Success)
             {
-                var singleMatch = SingleConditionTempRegex().Match(condition);
-                if (singleMatch.Success)
-                {
-                    var raw = singleMatch.Groups[2].Value.Replace(',', '.');
-                    return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var val)
-                           && IsValueInRange(sensorType, val);
-                }
-
-                var rangeMatch = RangeConditionTempRegex().Match(condition);
-                if (!rangeMatch.Success) return false;
-
-                var raw1 = rangeMatch.Groups[1].Value.Replace(',', '.');
-                var raw2 = rangeMatch.Groups[3].Value.Replace(',', '.');
-                if (!double.TryParse(raw1, NumberStyles.Float, CultureInfo.InvariantCulture, out var val1))
-                    return false;
-                if (!double.TryParse(raw2, NumberStyles.Float, CultureInfo.InvariantCulture, out var val2))
-                    return false;
-
-                var min = Math.Min(val1, val2);
-                var max = Math.Max(val1, val2);
-                return AreBothValuesInRange(sensorType, min, max);
-            }
-
-            {
-                var match = SingleConditionOtherRegex().Match(condition);
-                if (!match.Success) return false;
-
-                var raw = match.Groups[2].Value.Replace(',', '.');
+                var raw = singleMatch.Groups[2].Value.Replace(',', '.');
                 return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var val)
                        && IsValueInRange(sensorType, val);
             }
+
+            var rangeMatch = RangeConditionTempRegex().Match(condition);
+            if (!rangeMatch.Success) return false;
+
+            var raw1 = rangeMatch.Groups[1].Value.Replace(',', '.');
+            var raw2 = rangeMatch.Groups[3].Value.Replace(',', '.');
+            if (!double.TryParse(raw1, NumberStyles.Float, CultureInfo.InvariantCulture, out var val1))
+                return false;
+            if (!double.TryParse(raw2, NumberStyles.Float, CultureInfo.InvariantCulture, out var val2))
+                return false;
+
+            var min = Math.Min(val1, val2);
+            var max = Math.Max(val1, val2);
+            return AreBothValuesInRange(sensorType, min, max);
+
+        }
+
+        private static bool IsOtherSensorConditionValueInRange(string condition, string sensorType)
+        {
+            var match = SingleConditionOtherRegex().Match(condition);
+            if (!match.Success) return false;
+
+            var raw = match.Groups[2].Value.Replace(',', '.');
+            return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var val)
+                   && IsValueInRange(sensorType, val);
         }
 
         // Temperature single condition allows optional minus, dot or comma

--- a/server/Application/Validation/User/PatchUserPasswordDtoValidator.cs
+++ b/server/Application/Validation/User/PatchUserPasswordDtoValidator.cs
@@ -9,10 +9,12 @@ public sealed class PatchUserPasswordDtoValidator : AbstractValidator<PatchUserP
     {
         RuleFor(x => x.OldPassword)
             .NotEmpty().WithMessage("Password cannot be empty")
-            .MinimumLength(4).WithMessage("Password must be at least 4 characters.");
+            .Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$")
+            .WithMessage("Password must be at least 6 characters and include uppercase, lowercase, number, and special character.");
         
         RuleFor(x => x.NewPassword)
             .NotEmpty().WithMessage("Password cannot be empty")
-            .MinimumLength(4).WithMessage("Password must be at least 4 characters.");
+            .Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{6,}$")
+            .WithMessage("Password must be at least 6 characters and include uppercase, lowercase, number, and special character.");
     }
 }

--- a/server/Startup.Tests/AlertConditionTests/AlertConditionControllerTests.cs
+++ b/server/Startup.Tests/AlertConditionTests/AlertConditionControllerTests.cs
@@ -56,7 +56,7 @@ public class AlertConditionControllerTests : WebApplicationFactory<Program>
         // Login to get JWT
         var loginResp = await _client.PostAsJsonAsync(
             "/api/auth/login",
-            new { _testUser.Email, Password = "pass" }
+            new { _testUser.Email, Password = "Secret25!" }
         );
         loginResp.EnsureSuccessStatusCode();
         var authDto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();

--- a/server/Startup.Tests/AlertTests/AlertControllerTests.cs
+++ b/server/Startup.Tests/AlertTests/AlertControllerTests.cs
@@ -50,7 +50,7 @@ public class AlertControllerTests : WebApplicationFactory<Program>
         // get JWT
         var loginResp = await _client.PostAsJsonAsync(
             "/api/auth/login",
-            new { _testUser.Email, Password = "pass" }
+            new { _testUser.Email, Password = "Secret25!" }
         );
         loginResp.EnsureSuccessStatusCode();
         var authDto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();

--- a/server/Startup.Tests/Auth/AuthTests.cs
+++ b/server/Startup.Tests/Auth/AuthTests.cs
@@ -64,7 +64,7 @@ public class AuthTests : WebApplicationFactory<Program>
             new AuthRegisterDto
             {
                 Email = user.Email,
-                Password = "pass",
+                Password = "Secret25!",
                 FirstName = user.FirstName,
                 LastName = user.LastName,
                 Country = user.Country,
@@ -101,7 +101,7 @@ public class AuthTests : WebApplicationFactory<Program>
             AuthController.LoginRoute, new AuthLoginDto
             {
                 Email = user.Email,
-                Password = "pass"
+                Password = "Secret25!"
             });
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
     }
@@ -119,7 +119,7 @@ public class AuthTests : WebApplicationFactory<Program>
             new AuthLoginDto
             {
                 Email = user.Email,
-                Password = "invalid password"
+                Password = "Invalidpassword1!"
             });
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
     }

--- a/server/Startup.Tests/GreenhouseDeviceTests/GreenhouseDeviceControllerTests.cs
+++ b/server/Startup.Tests/GreenhouseDeviceTests/GreenhouseDeviceControllerTests.cs
@@ -36,7 +36,7 @@ public class GreenhouseDeviceControllerTests : WebApplicationFactory<Program>
         // Login to get JWT
         var loginResp = await _client.PostAsJsonAsync(
             "/api/auth/login",
-            new { _testUser.Email, Password = "pass" }
+            new { _testUser.Email, Password = "Secret25!" }
         );
         loginResp.EnsureSuccessStatusCode();
         var authDto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();
@@ -369,10 +369,13 @@ public class GreenhouseDeviceControllerTests : WebApplicationFactory<Program>
             $"/api/GreenhouseDevice/{GreenhouseDeviceController.DeleteDataRoute}?deviceId={foreignDeviceId}"
         );
 
-        // Assert: should be forbidden
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
-        Assert.That(Newtonsoft.Json.Linq.JObject.Parse(await response.Content.ReadAsStringAsync())["title"]?.ToString(),
-            Is.EqualTo("You do not own this device."));
+        Assert.Multiple(async () =>
+        {
+            // Assert: should be forbidden
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+            Assert.That(Newtonsoft.Json.Linq.JObject.Parse(await response.Content.ReadAsStringAsync())["title"]?.ToString(),
+                Is.EqualTo("You do not own this device."));
+        });
     }
     
     [Test]

--- a/server/Startup.Tests/PlantTests/PlantControllerTests.cs
+++ b/server/Startup.Tests/PlantTests/PlantControllerTests.cs
@@ -33,7 +33,7 @@ public class PlantControllerTests : WebApplicationFactory<Program>
         // Login to get JWT
         var loginResp = await _client.PostAsJsonAsync(
             "/api/auth/login",
-            new { _testUser.Email, Password = "pass" }
+            new { _testUser.Email, Password = "Secret25!" }
         );
         loginResp.EnsureSuccessStatusCode();
         var authDto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();

--- a/server/Startup.Tests/TestUtils/MockObjects.cs
+++ b/server/Startup.Tests/TestUtils/MockObjects.cs
@@ -17,9 +17,9 @@ public static class MockObjects
             UserId = userId,
             Role = role ?? Constants.UserRole,
             Email = $"testing{Guid.NewGuid()}@gmail.com",
-            Salt = "word", // password is "pass" and the hash is the combined pass + word hashed together
+            Salt = "eea62d44-c613-45b0-be6e-4dfa4f2f4973", // password is "Secret25!" and the hash is the combined pass + word hashed together
             Hash =
-                "b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86",
+                "b8986bb85a370d0f4fa81f85354993a9d79f60e557836c3776d41edb345dc97cca359fecb48ddf04db906e535c0158dfbe4f867a997bbdefe9c26c6c28081611",
             FirstName = "Test",
             LastName = "User",
             Birthday = DateTime.UtcNow.AddYears(-30),

--- a/server/Startup.Tests/UserDeviceTests/UserDeviceControllerTests.cs
+++ b/server/Startup.Tests/UserDeviceTests/UserDeviceControllerTests.cs
@@ -29,7 +29,7 @@ public class UserDeviceControllerTests : WebApplicationFactory<Program>
         _deviceId = device.DeviceId;
 
         var loginResp =
-            await _client.PostAsJsonAsync("/api/auth/login", new { _testUser.Email, Password = "pass" });
+            await _client.PostAsJsonAsync("/api/auth/login", new { _testUser.Email, Password = "Secret25!" });
         loginResp.EnsureSuccessStatusCode();
         var loginDto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();
         Assert.That(loginDto, Is.Not.Null);

--- a/server/Startup.Tests/UserSettingsTests/UserSettingsTests.cs
+++ b/server/Startup.Tests/UserSettingsTests/UserSettingsTests.cs
@@ -31,7 +31,7 @@ public class UserSettingsControllerTests : WebApplicationFactory<Program>
         db.Users.Add(_testUser);
         await db.SaveChangesAsync();
 
-        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", new { _testUser.Email, Password = "pass" });
+        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", new { _testUser.Email, Password = "Secret25!" });
         loginResp.EnsureSuccessStatusCode();
         var dto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();
         _jwt = dto!.Jwt;

--- a/server/Startup.Tests/UserTests/UserControllerTest.cs
+++ b/server/Startup.Tests/UserTests/UserControllerTest.cs
@@ -68,7 +68,7 @@ public class UserControllerTest
         // Log in and set JWT
         var loginResp = await _client.PostAsJsonAsync(
             "/api/auth/login", 
-            new { _testUser.Email, Password = "pass" });
+            new { _testUser.Email, Password = "Secret25!" });
         loginResp.EnsureSuccessStatusCode();
         
         var authDto = await loginResp.Content
@@ -134,7 +134,7 @@ public class UserControllerTest
         _client.DefaultRequestHeaders.Remove("Authorization");
         _testUser.Email = patchDto.NewEmail;
         
-        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", new { _testUser.Email, Password = "pass" });
+        var loginResp = await _client.PostAsJsonAsync("/api/auth/login", new { _testUser.Email, Password = "Secret25!" });
         loginResp.EnsureSuccessStatusCode();
         var authDto = await loginResp.Content.ReadFromJsonAsync<AuthResponseDto>();
         Assert.That(authDto, Is.Not.Null);
@@ -154,8 +154,8 @@ public class UserControllerTest
     {
         var patchDto = new PatchUserPasswordDto
         {
-            OldPassword = "pass",
-            NewPassword = "newPass123"
+            OldPassword = "Secret25!",
+            NewPassword = "newPass123!"
         };
 
         _passwordValidatorMock.Setup(v => v.ValidateAsync(patchDto, CancellationToken.None));
@@ -169,8 +169,8 @@ public class UserControllerTest
     {
         var patchDto = new PatchUserPasswordDto
         {
-            OldPassword = "wrongPass",
-            NewPassword = "newPass123"
+            OldPassword = "wrongPass!25",
+            NewPassword = "newPass123!"
         };
 
         var response = await _client.PatchAsJsonAsync($"api/User/{UserController.PatchUserPasswordRoute}", patchDto);
@@ -234,7 +234,7 @@ public class UserControllerTest
     public async Task PatchUserPassword_ShouldReturnBadRequest_WhenValidationFails()
     {
         // Arrange invalid DTO
-        var dto = new PatchUserPasswordDto { OldPassword = "pass", NewPassword = "" };
+        var dto = new PatchUserPasswordDto { OldPassword = "Secret25!", NewPassword = "" };
         _passwordValidatorMock
             .Setup(v => v.ValidateAsync(dto, It.IsAny<CancellationToken>()));
 
@@ -275,8 +275,8 @@ public class UserControllerTest
 
         var patchDto = new PatchUserPasswordDto
         {
-            OldPassword = "pass",
-            NewPassword = "newPass123"
+            OldPassword = "Secret25!",
+            NewPassword = "newPass123!"
         };
 
         var response = await _client.PatchAsJsonAsync($"api/User/{UserController.PatchUserPasswordRoute}", patchDto);

--- a/server/Startup.Tests/Validation/Auth/AuthLoginDtoValidatorTests.cs
+++ b/server/Startup.Tests/Validation/Auth/AuthLoginDtoValidatorTests.cs
@@ -42,6 +42,6 @@ public class AuthLoginDtoValidatorTests
     private static AuthLoginDto Valid() => new()
     {
         Email = "valid@email.com",
-        Password = "ValidPassword"
+        Password = "ValidPassword!1"
     };
 }

--- a/server/Startup.Tests/Validation/Auth/AuthRegisterDtoValidatorTests.cs
+++ b/server/Startup.Tests/Validation/Auth/AuthRegisterDtoValidatorTests.cs
@@ -96,6 +96,6 @@ public class AuthRegisterDtoValidatorTests
         Email = "valid@email.com",
         Birthday = DateTime.UtcNow.AddYears(-18),
         Country = "ValidCountry",
-        Password = "ValidPassword"
+        Password = "ValidPassword!1"
     };
 }

--- a/server/Startup.Tests/Validation/User/PatchUserPasswordDtoValidatorTests.cs
+++ b/server/Startup.Tests/Validation/User/PatchUserPasswordDtoValidatorTests.cs
@@ -40,7 +40,7 @@ public class PatchUserPasswordDtoValidatorTests
 
     private static PatchUserPasswordDto Valid() => new()
     {
-        OldPassword = "ValidPassword",
-        NewPassword = "NewValidPassword"
+        OldPassword = "ValidPassword1!",
+        NewPassword = "NewValidPassword1!"
     };
 }


### PR DESCRIPTION
**Email (Usersettings)**
![image](https://github.com/user-attachments/assets/8c6a8d1a-2e37-403a-86de-50b477a3ee20)
![image](https://github.com/user-attachments/assets/898311d8-4a97-4433-9052-d204d58ecfe6)
**Password (Usersettings)**
![image](https://github.com/user-attachments/assets/86dd973b-cd1f-4bf2-bc2c-a187977678a0)
![image](https://github.com/user-attachments/assets/fdc359a3-b423-4699-8498-2a6ba533adca)
![image](https://github.com/user-attachments/assets/3313f624-b9ef-462d-92ee-f855b79025b4)
**Plant (Edit)**
![image](https://github.com/user-attachments/assets/4eb4fc91-d1a9-4049-8278-22cadbabcfda)
**Plant (Create)**
![image](https://github.com/user-attachments/assets/6ca40bd8-ba8e-4944-93f8-43b1aefcbfa3)
**Login (AuthScreen)**
![image](https://github.com/user-attachments/assets/6a2648c9-bc91-467c-9f2b-6b62511b51b7)
![image](https://github.com/user-attachments/assets/4a0ece17-0cd5-4914-a457-d37416d7ca49)
**Register (AuthScreen)**
![image](https://github.com/user-attachments/assets/f296f434-192d-406f-a7d2-a2c021e0320a)
![image](https://github.com/user-attachments/assets/e473ae9f-00a0-4a95-9cda-3f796f1f9427)

**UnitTest**
![image](https://github.com/user-attachments/assets/12ea9e04-f578-4d07-9130-22b6893e8f2b)

**Changelog**
+ Added client-side validation to login/register and “change password”/“change email”  and plants flows
+ Display inline error when a new email is already in use, or the old password is incorrect
+ Introduced toast IDs throughout auth and settings to prevent duplicate notifications
+ Updated server-side validation rules to mirror the new frontend checks
+ Fixed two SonarQube issues
+ Refactored affected tests to maintain coverage
+ Increased font sizes in profile sections for better readability